### PR TITLE
scripts: Fix lambda mis-spelling

### DIFF
--- a/scripts/afhq/train_cat2dog_translation.py
+++ b/scripts/afhq/train_cat2dog_translation.py
@@ -19,12 +19,12 @@ def parse_cmdargs():
     )
 
     parser.add_argument(
-        '--labmda-gp', dest = 'lambda_gp', type = float,
+        '--lambda-gp', dest = 'lambda_gp', type = float,
         default = 1.0, help = 'magnitude of the gradient penalty'
     )
 
     parser.add_argument(
-        '--labmda-cycle', dest = 'lambda_cyc', type = float,
+        '--lambda-cycle', dest = 'lambda_cyc', type = float,
         default = 5.0, help = 'magnitude of the cycle-consisntecy loss'
     )
 

--- a/scripts/afhq/train_wild2cat_translation.py
+++ b/scripts/afhq/train_wild2cat_translation.py
@@ -19,12 +19,12 @@ def parse_cmdargs():
     )
 
     parser.add_argument(
-        '--labmda-gp', dest = 'lambda_gp', type = float,
+        '--lambda-gp', dest = 'lambda_gp', type = float,
         default = 1.0, help = 'magnitude of the gradient penalty'
     )
 
     parser.add_argument(
-        '--labmda-cycle', dest = 'lambda_cyc', type = float,
+        '--lambda-cycle', dest = 'lambda_cyc', type = float,
         default = 5.0, help = 'magnitude of the cycle-consisntecy loss'
     )
 

--- a/scripts/afhq/train_wild2dog_translation.py
+++ b/scripts/afhq/train_wild2dog_translation.py
@@ -19,12 +19,12 @@ def parse_cmdargs():
     )
 
     parser.add_argument(
-        '--labmda-gp', dest = 'lambda_gp', type = float,
+        '--lambda-gp', dest = 'lambda_gp', type = float,
         default = 1.0, help = 'magnitude of the gradient penalty'
     )
 
     parser.add_argument(
-        '--labmda-cycle', dest = 'lambda_cyc', type = float,
+        '--lambda-cycle', dest = 'lambda_cyc', type = float,
         default = 5.0, help = 'magnitude of the cycle-consisntecy loss'
     )
 

--- a/scripts/anime2selfie/train_anime2selfie_translation.py
+++ b/scripts/anime2selfie/train_anime2selfie_translation.py
@@ -19,12 +19,12 @@ def parse_cmdargs():
     )
 
     parser.add_argument(
-        '--labmda-gp', dest = 'lambda_gp', type = float,
+        '--lambda-gp', dest = 'lambda_gp', type = float,
         default = 0.01, help = 'magnitude of the gradient penalty'
     )
 
     parser.add_argument(
-        '--labmda-cycle', dest = 'lambda_cyc', type = float,
+        '--lambda-cycle', dest = 'lambda_cyc', type = float,
         default = 10.0, help = 'magnitude of the cycle-consisntecy loss'
     )
 

--- a/scripts/celeba/train_celeba_glasses_translation.py
+++ b/scripts/celeba/train_celeba_glasses_translation.py
@@ -19,12 +19,12 @@ def parse_cmdargs():
     )
 
     parser.add_argument(
-        '--labmda-gp', dest = 'lambda_gp', type = float,
+        '--lambda-gp', dest = 'lambda_gp', type = float,
         default = 0.01, help = 'magnitude of the gradient penalty'
     )
 
     parser.add_argument(
-        '--labmda-cycle', dest = 'lambda_cyc', type = float,
+        '--lambda-cycle', dest = 'lambda_cyc', type = float,
         default = 10.0, help = 'magnitude of the cycle-consisntecy loss'
     )
 

--- a/scripts/celeba/train_celeba_male2female_translation.py
+++ b/scripts/celeba/train_celeba_male2female_translation.py
@@ -19,12 +19,12 @@ def parse_cmdargs():
     )
 
     parser.add_argument(
-        '--labmda-gp', dest = 'lambda_gp', type = float,
+        '--lambda-gp', dest = 'lambda_gp', type = float,
         default = 0.01, help = 'magnitude of the gradient penalty'
     )
 
     parser.add_argument(
-        '--labmda-cycle', dest = 'lambda_cyc', type = float,
+        '--lambda-cycle', dest = 'lambda_cyc', type = float,
         default = 10.0, help = 'magnitude of the cycle-consisntecy loss'
     )
 

--- a/scripts/celeba_hq/train_m2f_translation.py
+++ b/scripts/celeba_hq/train_m2f_translation.py
@@ -19,12 +19,12 @@ def parse_cmdargs():
     )
 
     parser.add_argument(
-        '--labmda-gp', dest = 'lambda_gp', type = float,
+        '--lambda-gp', dest = 'lambda_gp', type = float,
         default = 1.0, help = 'magnitude of the gradient penalty'
     )
 
     parser.add_argument(
-        '--labmda-cycle', dest = 'lambda_cyc', type = float,
+        '--lambda-cycle', dest = 'lambda_cyc', type = float,
         default = 5.0, help = 'magnitude of the cycle-consisntecy loss'
     )
 


### PR DESCRIPTION
I accidentally misspelled `lambda` command line parameters.

This PR fixes misspelling.